### PR TITLE
(change): adjustment of the backend endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1]
+
+- [backend](./backend) CHANGE: adjust the endpoints for better represent the UI requirements. The boards and columns are separated to be utilized more appropriately.
+
 ## [0.6.0]
 
 - [backend](./web-client) FEATURE: added a basic implementation of the modal wrapper, including of the basic keyboard control 

--- a/backend/boards.json
+++ b/backend/boards.json
@@ -1,12 +1,14 @@
 [
   {
-    "id": "743b2d07-5a4c-454a-9489-9f0562fa46d2",
-    "name": "Roadmap",
-    "columns": [
-      {
-        "id": "d43cba82-a324-4922-9577-d61068152971",
-        "name": "Todo"
-      }
-    ]
+    "id": "3fca43e5-7aac-4ae8-97f8-f028246dbe92",
+    "name": "Updated Platform launch"
+  },
+  {
+    "id": "17b5123b-1992-4dac-b859-5fdef1950b1a",
+    "name": "Roadmap"
+  },
+  {
+    "id": "55494f14-8bb8-4db9-940d-223b4a4e4066",
+    "name": "Platform Launch"
   }
 ]

--- a/backend/cmd/api/columns.go
+++ b/backend/cmd/api/columns.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (app *application) getColumnsByBoardID(w http.ResponseWriter, r *http.Request) {
+	boardId, err := app.readUrlParamField(r, "boardId")
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	columns, err := app.models.Columns.GetByBoardID(boardId)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	headers := make(http.Header)
+	headers.Set("Location", fmt.Sprintf("/v1/boards/%s/columns", boardId))
+
+	err = app.writeJSON(w, http.StatusOK, envelope{"columns": columns}, headers)
+}

--- a/backend/cmd/api/routes.go
+++ b/backend/cmd/api/routes.go
@@ -14,6 +14,7 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/v1/boards/:boardId", app.getBoardById)
 	router.HandlerFunc(http.MethodPut, "/v1/boards/:boardId", app.updateBoard)
 	router.HandlerFunc(http.MethodDelete, "/v1/boards/:boardId", app.deleteBoard)
+	router.HandlerFunc(http.MethodGet, "/v1/boards/:boardId/columns", app.getColumnsByBoardID)
 
 	return app.recoverPanic(router)
 }

--- a/backend/columns.json
+++ b/backend/columns.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "6e092df7-42c7-4fff-8988-9033fc661a57",
+    "boardId": "3fca43e5-7aac-4ae8-97f8-f028246dbe92",
+    "name": "(Updated) Todo",
+    "color": "hsl(0,42%,41%)"
+  },
+  {
+    "id": "5094d8b2-e8e9-4248-9309-6067ad18d436",
+    "boardId": "3fca43e5-7aac-4ae8-97f8-f028246dbe92",
+    "name": "In progress",
+    "color": "hsl(43,93%,81%)"
+  },
+  {
+    "id": "f6e9bd76-2257-4258-8bf5-150e637e0c4b",
+    "boardId": "3fca43e5-7aac-4ae8-97f8-f028246dbe92",
+    "name": "Done",
+    "color": "hsl(83,52%,75%)"
+  },
+  {
+    "id": "aefa13de-20c3-4157-bd57-f06c289d40ee",
+    "boardId": "17b5123b-1992-4dac-b859-5fdef1950b1a",
+    "name": "Todo",
+    "color": "hsl(69,70%,78%)"
+  },
+  {
+    "id": "1d7b0a93-2812-43eb-9210-f77d6ce8b117",
+    "boardId": "17b5123b-1992-4dac-b859-5fdef1950b1a",
+    "name": "Doing",
+    "color": "hsl(158,52%,75%)"
+  },
+  {
+    "id": "80c473f9-7dae-40af-9ea4-8164ec778e87",
+    "boardId": "55494f14-8bb8-4db9-940d-223b4a4e4066",
+    "name": "Todo",
+    "color": "hsl(164,72%,83%)"
+  },
+  {
+    "id": "bd42318a-ac40-477d-813a-30e7be680c68",
+    "boardId": "55494f14-8bb8-4db9-940d-223b4a4e4066",
+    "name": "Doing",
+    "color": "hsl(217,64%,68%)"
+  }
+]

--- a/backend/internal/data/columns.go
+++ b/backend/internal/data/columns.go
@@ -1,0 +1,116 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"time"
+)
+
+type Column struct {
+	ID        string    `json:"id"`
+	BoardID   string    `json:"boardId"`
+	Name      string    `json:"name"`
+	Color     string    `json:"color"`
+	CreatedAt time.Time `json:"-"`
+}
+
+type ColumnModel struct{}
+
+func (c ColumnModel) GetByBoardID(id string) ([]Column, error) {
+	jsonData, err := readJSONFile("columns.json")
+	if err != nil {
+		fmt.Println("error reading file: ", err)
+		return nil, err
+	}
+
+	var storedData []Column
+	err = json.Unmarshal(jsonData, &storedData)
+
+	result := getColumnsByBoardID(id, storedData)
+
+	if result == nil {
+		result = []Column{}
+	}
+
+	return result, err
+}
+
+func (c ColumnModel) Insert(columns []Column) error {
+	jsonData, err := readJSONFile("columns.json")
+	if err != nil {
+		fmt.Println("error reading file: ", err)
+		return err
+	}
+
+	var storedData []Column
+	err = json.Unmarshal(jsonData, &storedData)
+
+	for index := range columns {
+		columns[index].ID = uuid.NewString()
+		columns[index].Color = generateColumnColor()
+		columns[index].CreatedAt = time.Now()
+	}
+
+	storedData = append(storedData, columns...)
+
+	err = writeJSONFile("columns.json", storedData)
+	if err != nil {
+		fmt.Println("Error writing file: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c ColumnModel) Update(columns []Column) error {
+	jsonData, err := readJSONFile("columns.json")
+	if err != nil {
+		fmt.Println("error reading file: ", err)
+		return err
+	}
+
+	var storedData []Column
+	err = json.Unmarshal(jsonData, &storedData)
+
+	for index, column := range columns {
+		element := findColumnElementIfExist(column.ID, storedData)
+		if element != nil {
+			columns[index].Color = element.Color
+			columns[index].CreatedAt = element.CreatedAt
+		} else {
+			columns[index].ID = uuid.NewString()
+			columns[index].Color = generateColumnColor()
+			columns[index].CreatedAt = time.Now()
+		}
+	}
+
+	err = writeJSONFile("columns.json", columns)
+	if err != nil {
+		fmt.Println("Error writing file: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c ColumnModel) Delete(id string) error {
+	jsonData, err := readJSONFile("columns.json")
+	if err != nil {
+		fmt.Println("error reading file: ", err)
+		return err
+	}
+
+	var storedData []Column
+	err = json.Unmarshal(jsonData, &storedData)
+
+	result := filterColumnsByBoardID(id, storedData)
+
+	err = writeJSONFile("columns.json", result)
+	if err != nil {
+		fmt.Println("Error writing file: ", err)
+		return err
+	}
+
+	return nil
+}

--- a/backend/internal/data/helpers.go
+++ b/backend/internal/data/helpers.go
@@ -1,0 +1,55 @@
+package data
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+func generateColumnColor() string {
+	randomInt := func(min, max int) int {
+		return int(math.Floor(float64(rand.Intn(max-min+1) + min)))
+	}
+
+	h := randomInt(0, 360)
+	s := randomInt(42, 98)
+	l := randomInt(40, 90)
+
+	return fmt.Sprintf("hsl(%d,%d%%,%d%%)", h, s, l)
+}
+
+func findColumnElementIfExist(id string, data []Column) *Column {
+	var result *Column
+
+	for _, column := range data {
+		if column.ID == id {
+			result = &column
+		}
+	}
+
+	return result
+}
+
+func getColumnsByBoardID(id string, data []Column) []Column {
+	var result []Column
+
+	for _, column := range data {
+		if column.BoardID == id {
+			result = append(result, column)
+		}
+	}
+
+	return result
+}
+
+func filterColumnsByBoardID(id string, data []Column) []Column {
+	var result []Column
+
+	for _, column := range data {
+		if column.BoardID != id {
+			result = append(result, column)
+		}
+	}
+
+	return result
+}

--- a/backend/internal/data/models.go
+++ b/backend/internal/data/models.go
@@ -7,11 +7,13 @@ var (
 )
 
 type Models struct {
-	Boards BoardModel
+	Boards  BoardModel
+	Columns ColumnModel
 }
 
 func NewModels() Models {
 	return Models{
-		Boards: BoardModel{},
+		Boards:  BoardModel{},
+		Columns: ColumnModel{},
 	}
 }

--- a/backend/sandbox.http
+++ b/backend/sandbox.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 ###
 
 ### Get specific board by an ID
-GET http://localhost:4000/v1/boards/743b2d07-5a4c-454a-9489-9f0562fa46d2
+GET http://localhost:4000/v1/boards/3fca43e5-7aac-4ae8-97f8-f028246dbe92
 Content-Type: application/json
 ###
 
@@ -16,18 +16,23 @@ Content-Type: application/json
 POST http://localhost:4000/v1/boards
 Content-Type: application/json
 
-{"name": "Roadmap", "columns":  [{ "name": "Todo" }]}
+{"name": "Platform Launch", "columns":  [{ "name": "Todo" }, { "name": "Doing" }]}
 ###
 
 
 ### Update a board
-PUT http://localhost:4000/v1/boards/3c7d1cf2-2300-4d31-ada1-ed2a06096f80
+PUT http://localhost:4000/v1/boards/3fca43e5-7aac-4ae8-97f8-f028246dbe92
 Content-Type: application/json
 
-{"id":  "3c7d1cf2-2300-4d31-ada1-ed2a06096f80", "name": "Updated Platform launch", "columns":  [{ "id": "203e97e6-df76-499e-baea-e60ce7a90de5", "name": "(Updated) Todo" }, { "id": "30d608f5-339d-491a-9739-4327b3ce8ba3", "name": "(Updated) In progress" }, { "name": "Done" }]}
+{"id":  "3fca43e5-7aac-4ae8-97f8-f028246dbe92", "name": "Updated Platform launch", "columns":  [{ "id": "6e092df7-42c7-4fff-8988-9033fc661a57", "name": "(Updated) Todo" }, { "name": "In progress" }, { "name": "Done" }]}
 ###
 
 ### Delete specific board by an ID
-DELETE http://localhost:4000/v1/boards/3c7d1cf2-2300-4d31-ada1-ed2a06096f80
+DELETE http://localhost:4000/v1/boards/a231b3fd-72e7-4f2b-a79d-6f3b226bf43f
+Content-Type: application/json
+###
+
+### Get all columns by an ID
+GET http://localhost:4000/v1/boards/55494f14-8bb8-4db9-940d-223b4a4e4067/columns
 Content-Type: application/json
 ###


### PR DESCRIPTION
## Description

This PR contains a few changes to accommodate the UI a requirements a bit better, including:

- **flattening the JSON structure**. Despite the fact the backend is currently works with a filesystem, the original plan was to combines the boards and columns data together in a JSON response. And add the tasks later (into a separate structure, properly reference). However, after revisiting the UI design, it doesn't appear to me anymore that such a structure would be required and it would be more beneficial to have more flatten JSON response.
- **boards data** are now listed in an array, that contains only an **id** of a board and the **name** that is (for now) stored in a `boards.json`
- **columns data** are created alongside the board payload, however, there are stored (for now) in a dedicated `columns.json` whilst being linked with the `boards` records.
- when board is modified, it also adjust the children (columns), that can be edited, extended or removed. However, the columns themselves could be just listed on their own (will be used within a form for a selector).

In a later PR, we will add task entity to be able to represent the full hierarchy. For now, the current tweak should help with the progress on the frontend side.  