### PR TITLE
(feat): Add create or edit task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0]
+
+- [web-client](./web-client) FEATURE: added a functionality for creating a new task/editing an existing one.
+- [web-client](./web-client) CHANGE: simplified the exception messages in the https functionality.
+
 ## [0.7.0]
 
 - [web-client](./web-client) FEATURE: replaced the mock for displaying the tasks on board by an actual data from backend.

--- a/backend/columns.json
+++ b/backend/columns.json
@@ -16,5 +16,17 @@
     "boardId": "328ba7fa-0508-4c04-865b-d4630d6255aa",
     "name": "Done",
     "color": "hsl(13,98%,42%)"
+  },
+  {
+    "id": "3ea55c2c-7ada-4756-ac60-a66a60b62a0e",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "name": "Test",
+    "color": "hsl(107,42%,42%)"
+  },
+  {
+    "id": "cc432c2a-821d-4b71-877a-7194ffeea0bd",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "name": "Done",
+    "color": "hsl(241,91%,55%)"
   }
 ]

--- a/backend/subtasks.json
+++ b/backend/subtasks.json
@@ -1,206 +1,8 @@
 [
   {
-    "id": "UwsK18_5H8",
-    "taskId": "LG-cjbh-Cl",
-    "title": "Prepare competitor analysis report",
-    "completed": true
-  },
-  {
-    "id": "-xsKN-v_mS",
-    "taskId": "lDnfW_rhW4",
-    "title": "Finalize onboarding UI designs",
-    "completed": false
-  },
-  {
-    "id": "hes15u0fdr",
-    "taskId": "V2RutyHIVb",
-    "title": "Finalize UI for settings page",
-    "completed": false
-  },
-  {
-    "id": "MbrkTXx880",
-    "taskId": "gJ9FbOoFpo",
-    "title": "Execute QA tests for core features",
-    "completed": false
-  },
-  {
-    "id": "RBeGbqYqZO",
-    "taskId": "71GGdfqOEf",
-    "title": "Test business models in the market",
-    "completed": false
-  },
-  {
-    "id": "xn192-pfEU",
-    "taskId": "N8-XrVCpnQ",
-    "title": "Create wireframe",
-    "completed": false
-  },
-  {
-    "id": "2LENW-YLXr",
-    "taskId": "JCNrTtzuEc",
-    "title": "Make iterative UI updates",
-    "completed": true
-  },
-  {
-    "id": "ixyj24Y2f5",
-    "taskId": "V2RutyHIVb",
-    "title": "Refine search page designs",
-    "completed": false
-  },
-  {
-    "id": "ZPGOttnAVB",
-    "taskId": "j8xelUqoph",
-    "title": "Research authentication methods",
-    "completed": true
-  },
-  {
-    "id": "O6l1gRtsch",
-    "taskId": "BW7KvUIWYl",
-    "title": "Research market trends",
-    "completed": true
-  },
-  {
-    "id": "fJGzC7mtmg",
-    "taskId": "1fA-X67Fje",
-    "title": "Implement search endpoints",
-    "completed": false
-  },
-  {
-    "id": "GjjgRV3xAf",
-    "taskId": "LG-cjbh-Cl",
-    "title": "Analyze top competitors",
-    "completed": true
-  },
-  {
-    "id": "9IHC3o8l3j",
-    "taskId": "j8xelUqoph",
-    "title": "Develop authentication APIs",
-    "completed": false
-  },
-  {
-    "id": "gzCNRU6Ams",
-    "taskId": "vbFaTQ7QIx",
-    "title": "Sketch search UI mockups",
-    "completed": true
-  },
-  {
-    "id": "N6vVxfGCai",
-    "taskId": "N8-XrVCpnQ",
-    "title": "Review UI with team",
-    "completed": true
-  },
-  {
-    "id": "y83TAL_N5P",
-    "taskId": "gGbQ-MHEXD",
-    "title": "Conduct usability tests with customers",
-    "completed": true
-  },
-  {
-    "id": "Q_IjkCstMG",
+    "id": "sAn0-CFcbu",
     "taskId": "c1HB6nBcQo",
-    "title": "Review account security features",
-    "completed": false
-  },
-  {
-    "id": "oJaLVL2tAx",
-    "taskId": "I5xWHNYCuR",
-    "title": "Identify key market segments",
-    "completed": true
-  },
-  {
-    "id": "bvWPbRJP6T",
-    "taskId": "1fA-X67Fje",
-    "title": "Research search API designs",
-    "completed": true
-  },
-  {
-    "id": "QODRBL02Zr",
-    "taskId": "gGbQ-MHEXD",
-    "title": "Create paper prototype",
-    "completed": true
-  },
-  {
-    "id": "7TAPVK5_Kk",
-    "taskId": "WkdHjPfTSp",
-    "title": "Design main settings page",
-    "completed": false
-  },
-  {
-    "id": "3xO-kNbmVE",
-    "taskId": "WkdHjPfTSp",
-    "title": "Research user preferences for settings",
-    "completed": false
-  },
-  {
-    "id": "c314c456-30eb-4c79-962d-1382675e4233",
-    "taskId": "1b6edb0a-e7a1-40c9-8fb9-8e322c2c8b16",
-    "title": "Custom subtask2",
-    "completed": false
-  },
-  {
-    "id": "Z4RnRNPoAG",
-    "taskId": "V2RutyHIVb",
-    "title": "Design initial settings page mockups",
-    "completed": true
-  },
-  {
-    "id": "WURREwR6nV",
-    "taskId": "lDnfW_rhW4",
-    "title": "Design initial onboarding sketches",
-    "completed": true
-  },
-  {
-    "id": "XGsWdXWMSG",
-    "taskId": "c1HB6nBcQo",
-    "title": "Implement authentication API",
-    "completed": true
-  },
-  {
-    "id": "UPPSrjpB1K",
-    "taskId": "JCNrTtzuEc",
-    "title": "Collect feedback from usability tests",
-    "completed": true
-  },
-  {
-    "id": "blbJ6VpLUx",
-    "taskId": "JCNrTtzuEc",
-    "title": "Analyze test results",
-    "completed": true
-  },
-  {
-    "id": "xhKWfUUhk_",
-    "taskId": "N8-XrVCpnQ",
-    "title": "Design UI layout",
-    "completed": true
-  },
-  {
-    "id": "S7wprh2XZC",
-    "taskId": "71GGdfqOEf",
-    "title": "Create business model variations",
-    "completed": false
-  },
-  {
-    "id": "e5b2eead-495b-461a-b302-01b0372bf93b",
-    "taskId": "1b6edb0a-e7a1-40c9-8fb9-8e322c2c8b16",
-    "title": "Custom subtask1",
-    "completed": false
-  },
-  {
-    "id": "zekbXUZuNM",
-    "taskId": "71GGdfqOEf",
-    "title": "Analyze competitor pricing models",
-    "completed": true
-  },
-  {
-    "id": "TGh_f4CGeo",
-    "taskId": "BW7KvUIWYl",
-    "title": "Document market research findings",
-    "completed": true
-  },
-  {
-    "id": "L_kUmH2ZUR",
-    "taskId": "nyosLF2vw6",
-    "title": "Create high-fidelity wireframe prototype",
+    "title": "Research API endpoints for account management",
     "completed": true
   },
   {
@@ -210,9 +12,75 @@
     "completed": false
   },
   {
-    "id": "f0fabbda-eae2-42a2-8093-b6576b1ff265",
-    "taskId": "1b6edb0a-e7a1-40c9-8fb9-8e322c2c8b16",
-    "title": "Custom subtask3",
+    "id": "3599bfb4-92ea-4542-9e64-764c3aa19d19",
+    "taskId": "55c56dfb-d0ff-4406-9d77-37003a8caa44",
+    "title": "Make coffee",
+    "completed": false
+  },
+  {
+    "id": "705fc5ff-4d73-4bc3-bb0a-6124e3a88eaf",
+    "taskId": "3a44b04b-22e8-4eb3-8621-86d2f7786064",
+    "title": "Another subtask",
+    "completed": true
+  },
+  {
+    "id": "hJExqcIYMW",
+    "taskId": "gJ9FbOoFpo",
+    "title": "Compile test cases for user journeys",
+    "completed": false
+  },
+  {
+    "id": "-xsKN-v_mS",
+    "taskId": "lDnfW_rhW4",
+    "title": "Finalize onboarding UI designs",
+    "completed": false
+  },
+  {
+    "id": "O6l1gRtsch",
+    "taskId": "BW7KvUIWYl",
+    "title": "Research market trends",
+    "completed": true
+  },
+  {
+    "id": "L_kUmH2ZUR",
+    "taskId": "nyosLF2vw6",
+    "title": "Create high-fidelity wireframe prototype",
+    "completed": false
+  },
+  {
+    "id": "ixyj24Y2f5",
+    "taskId": "V2RutyHIVb",
+    "title": "Refine search page designs",
+    "completed": false
+  },
+  {
+    "id": "hes15u0fdr",
+    "taskId": "V2RutyHIVb",
+    "title": "Finalize UI for settings page",
+    "completed": false
+  },
+  {
+    "id": "f2650816-97fb-4920-9a85-45f4a8ddeef5",
+    "taskId": "3a44b04b-22e8-4eb3-8621-86d2f7786064",
+    "title": "Make chocolate",
+    "completed": true
+  },
+  {
+    "id": "XGsWdXWMSG",
+    "taskId": "c1HB6nBcQo",
+    "title": "Implement authentication API",
+    "completed": true
+  },
+  {
+    "id": "zekbXUZuNM",
+    "taskId": "71GGdfqOEf",
+    "title": "Analyze competitor pricing models",
+    "completed": true
+  },
+  {
+    "id": "fJGzC7mtmg",
+    "taskId": "1fA-X67Fje",
+    "title": "Implement search endpoints",
     "completed": false
   },
   {
@@ -222,15 +90,165 @@
     "completed": true
   },
   {
-    "id": "sAn0-CFcbu",
-    "taskId": "c1HB6nBcQo",
-    "title": "Research API endpoints for account management",
+    "id": "bvWPbRJP6T",
+    "taskId": "1fA-X67Fje",
+    "title": "Research search API designs",
     "completed": true
   },
   {
-    "id": "hJExqcIYMW",
+    "id": "Z4RnRNPoAG",
+    "taskId": "V2RutyHIVb",
+    "title": "Design initial settings page mockups",
+    "completed": true
+  },
+  {
+    "id": "N6vVxfGCai",
+    "taskId": "N8-XrVCpnQ",
+    "title": "Review UI with team",
+    "completed": true
+  },
+  {
+    "id": "Q_IjkCstMG",
+    "taskId": "c1HB6nBcQo",
+    "title": "Review account security features",
+    "completed": false
+  },
+  {
+    "id": "TGh_f4CGeo",
+    "taskId": "BW7KvUIWYl",
+    "title": "Document market research findings",
+    "completed": true
+  },
+  {
+    "id": "xhKWfUUhk_",
+    "taskId": "N8-XrVCpnQ",
+    "title": "Design UI layout",
+    "completed": true
+  },
+  {
+    "id": "QODRBL02Zr",
+    "taskId": "gGbQ-MHEXD",
+    "title": "Create paper prototype",
+    "completed": true
+  },
+  {
+    "id": "2LENW-YLXr",
+    "taskId": "JCNrTtzuEc",
+    "title": "Make iterative UI updates",
+    "completed": true
+  },
+  {
+    "id": "9IHC3o8l3j",
+    "taskId": "j8xelUqoph",
+    "title": "Develop authentication APIs",
+    "completed": false
+  },
+  {
+    "id": "S7wprh2XZC",
+    "taskId": "71GGdfqOEf",
+    "title": "Create business model variations",
+    "completed": false
+  },
+  {
+    "id": "ZPGOttnAVB",
+    "taskId": "j8xelUqoph",
+    "title": "Research authentication methods",
+    "completed": true
+  },
+  {
+    "id": "b9cc3a6c-1643-4e3a-bde5-330f8bccb91b",
+    "taskId": "f16a3786-90e1-48ed-8a11-a23c872feb6f",
+    "title": "Make coffee",
+    "completed": false
+  },
+  {
+    "id": "UwsK18_5H8",
+    "taskId": "LG-cjbh-Cl",
+    "title": "Prepare competitor analysis report",
+    "completed": true
+  },
+  {
+    "id": "8a875970-9c61-475a-bc25-9eb3db117f2b",
+    "taskId": "ba350d13-b5fe-4047-a969-aef053ad3a55",
+    "title": "subtask 1",
+    "completed": false
+  },
+  {
+    "id": "oJaLVL2tAx",
+    "taskId": "I5xWHNYCuR",
+    "title": "Identify key market segments",
+    "completed": false
+  },
+  {
+    "id": "GjjgRV3xAf",
+    "taskId": "LG-cjbh-Cl",
+    "title": "Analyze top competitors",
+    "completed": true
+  },
+  {
+    "id": "3xO-kNbmVE",
+    "taskId": "WkdHjPfTSp",
+    "title": "Research user preferences for settings",
+    "completed": false
+  },
+  {
+    "id": "MbrkTXx880",
     "taskId": "gJ9FbOoFpo",
-    "title": "Compile test cases for user journeys",
+    "title": "Execute QA tests for core features",
+    "completed": false
+  },
+  {
+    "id": "0020f2e3-4176-496e-ad1c-a78ffef8f3bd",
+    "taskId": "68136d44-7e42-4d77-a8ff-15b9adfa0220",
+    "title": "Make coffee",
+    "completed": false
+  },
+  {
+    "id": "blbJ6VpLUx",
+    "taskId": "JCNrTtzuEc",
+    "title": "Analyze test results",
+    "completed": true
+  },
+  {
+    "id": "gzCNRU6Ams",
+    "taskId": "vbFaTQ7QIx",
+    "title": "Sketch search UI mockups",
+    "completed": true
+  },
+  {
+    "id": "y83TAL_N5P",
+    "taskId": "gGbQ-MHEXD",
+    "title": "Conduct usability tests with customers",
+    "completed": true
+  },
+  {
+    "id": "7TAPVK5_Kk",
+    "taskId": "WkdHjPfTSp",
+    "title": "Design main settings page",
+    "completed": false
+  },
+  {
+    "id": "UPPSrjpB1K",
+    "taskId": "JCNrTtzuEc",
+    "title": "Collect feedback from usability tests",
+    "completed": true
+  },
+  {
+    "id": "xn192-pfEU",
+    "taskId": "N8-XrVCpnQ",
+    "title": "Create wireframe",
+    "completed": false
+  },
+  {
+    "id": "WURREwR6nV",
+    "taskId": "lDnfW_rhW4",
+    "title": "Design initial onboarding sketches",
+    "completed": true
+  },
+  {
+    "id": "RBeGbqYqZO",
+    "taskId": "71GGdfqOEf",
+    "title": "Test business models in the market",
     "completed": false
   }
 ]

--- a/backend/tasks.json
+++ b/backend/tasks.json
@@ -79,7 +79,7 @@
   {
     "id": "nyosLF2vw6",
     "boardId": "328ba7fa-0508-4c04-865b-d4630d6255aa",
-    "columnId": "b7dbeee6-f5da-4609-aea1-2dfd1f10000c",
+    "columnId": "448526a9-1231-484a-aac0-e4e0d25aebdc",
     "title": "Create wireframe prototype",
     "description": "Develop a wireframe prototype to visualize the layout and functionality of the user interface for testing purposes."
   },
@@ -119,10 +119,38 @@
     "description": "Conduct thorough market research to gather insights into trends, customer needs, and competitive landscape."
   },
   {
-    "id": "1b6edb0a-e7a1-40c9-8fb9-8e322c2c8b16",
-    "boardId": "328ba7fa-0508-4c04-865b-d4630d6255aa",
-    "columnId": "b7dbeee6-f5da-4609-aea1-2dfd1f10000c",
+    "id": "f16a3786-90e1-48ed-8a11-a23c872feb6f",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "columnId": "",
+    "title": "Test",
+    "description": "just a quick test"
+  },
+  {
+    "id": "ba350d13-b5fe-4047-a969-aef053ad3a55",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "columnId": "",
     "title": "A task",
-    "description": "A description"
+    "description": "Task within a new board"
+  },
+  {
+    "id": "68136d44-7e42-4d77-a8ff-15b9adfa0220",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "columnId": "",
+    "title": "Test task",
+    "description": "dsfdsfdsf"
+  },
+  {
+    "id": "55c56dfb-d0ff-4406-9d77-37003a8caa44",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "columnId": "3ea55c2c-7ada-4756-ac60-a66a60b62a0e",
+    "title": "Test",
+    "description": "fdsfdsf"
+  },
+  {
+    "id": "3a44b04b-22e8-4eb3-8621-86d2f7786064",
+    "boardId": "5aecb2d6-8277-4098-85dd-305e2bef4629",
+    "columnId": "cc432c2a-821d-4b71-877a-7194ffeea0bd",
+    "title": "Another test",
+    "description": "fdsfsd"
   }
 ]

--- a/web-client/src/hooks/useBoardFormProvider.ts
+++ b/web-client/src/hooks/useBoardFormProvider.ts
@@ -1,25 +1,15 @@
-import type { ModalScreenKey } from "@/types/modals"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
-  BoardForm,
+  type BoardForm,
   boardFormSchema,
   defaultBoardFormValues,
 } from "@/types/boards"
 
-export function useBoardFormProvider(modalScreenKey: ModalScreenKey) {
-  const methods = useForm<BoardForm>({
+export function useBoardFormProvider() {
+  return useForm<BoardForm>({
     mode: "all",
     resolver: zodResolver(boardFormSchema),
     defaultValues: defaultBoardFormValues,
   })
-
-  switch (modalScreenKey) {
-    case "AddBoardScreen":
-      return methods
-
-    case "None":
-    default:
-      return methods
-  }
 }

--- a/web-client/src/hooks/useTaskFormProvider.ts
+++ b/web-client/src/hooks/useTaskFormProvider.ts
@@ -1,0 +1,15 @@
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  type TaskForm,
+  taskFormSchema,
+  defaultTaskFormValues,
+} from "@/types/tasks"
+
+export function useTaskFormProvider() {
+  return useForm<TaskForm>({
+    mode: "all",
+    resolver: zodResolver(taskFormSchema),
+    defaultValues: defaultTaskFormValues,
+  })
+}

--- a/web-client/src/services/api.ts
+++ b/web-client/src/services/api.ts
@@ -12,8 +12,8 @@ import { mapBoardData } from "@/utils/helpers/mapData.helpers"
 import {
   Task,
   TaskDelete,
+  TaskDetail,
   taskDeleteSchema,
-  TaskDetailSchema,
   taskSchema,
 } from "@/types/tasks"
 
@@ -144,9 +144,7 @@ export const getTaskDetailById = async (
   return result.data
 }
 
-export const updateTaskDetailById = async (
-  data: TaskDetailSchema
-): Promise<Task> => {
+export const updateTaskDetailById = async (data: TaskDetail): Promise<Task> => {
   const response = await axiosInstance.put<{ task: Task }>(
     `/boards/${data.boardId}/tasks/${data.id}`,
     data

--- a/web-client/src/services/mutations.ts
+++ b/web-client/src/services/mutations.ts
@@ -1,11 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   createBoard,
-  updateBoard,
+  createTask,
+  updateBoardById,
+  updateTaskById,
   deleteBoardById,
   updateTaskDetailById,
   deleteTaskById,
 } from "@/services/api"
+import type { TaskForm } from "@/types/tasks"
 
 export function useCreateBoard() {
   const queryClient = useQueryClient()
@@ -25,7 +28,7 @@ export function useEditBoard() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: updateBoard,
+    mutationFn: updateBoardById,
     onSuccess: async ({ id: boardId }, variables) => {
       await queryClient.invalidateQueries({ queryKey: ["boards"] })
 
@@ -51,6 +54,36 @@ export function useDeleteBoard() {
       await queryClient.invalidateQueries({ queryKey: ["boards"] })
       queryClient.removeQueries({
         queryKey: ["boards/columns", { boardId }],
+      })
+    },
+  })
+}
+
+export function useCreateTask(boardId?: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: TaskForm) => createTask(data, boardId),
+    onSuccess: async ({ boardId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["boards/tasks", { boardId }],
+      })
+    },
+  })
+}
+
+export function useUpdateTask(boardId?: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: TaskForm) => updateTaskById(data, boardId),
+    onSuccess: async ({ id: taskId, boardId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["boards/tasks", { boardId }],
+      })
+
+      await queryClient.invalidateQueries({
+        queryKey: ["boards/task", { boardId, taskId }],
       })
     },
   })

--- a/web-client/src/types/api.ts
+++ b/web-client/src/types/api.ts
@@ -16,7 +16,24 @@ export type BoardEdit = {
   }[]
 }
 
-export type BoardDelete = {
+export type TaskCreate = {
+  variant: "create"
+  title: string
+  description: string
+  columnId: string
+  subtasks: {
+    title: string
+  }[]
+}
+
+export type TaskEdit = {
+  variant: "edit"
   id: string
-  message: string
+  title: string
+  description: string
+  columnId: string
+  subtasks: {
+    id: string
+    title: string
+  }[]
 }

--- a/web-client/src/types/tasks.ts
+++ b/web-client/src/types/tasks.ts
@@ -44,30 +44,23 @@ export const taskFormSchema = z.discriminatedUnion("variant", [
       .string()
       .min(1, { message: fieldErrorTooShort })
       .max(20, { message: fieldErrorTooLong }),
-    description: z.string(),
+    description: z.string().min(1, { message: fieldErrorTooShort }),
     subtasks: z.array(
       z.object({
-        title: z
-          .string()
-          .min(1, { message: fieldErrorTooShort })
-          .max(20, { message: fieldErrorTooLong }),
+        title: z.string().min(1, { message: fieldErrorTooShort }),
       })
     ),
     columnId: z.string(),
   }),
   z.object({
     variant: z.literal("edit"),
-    title: z
-      .string()
-      .min(1, { message: fieldErrorTooShort })
-      .max(20, { message: fieldErrorTooLong }),
-    description: z.string(),
+    id: z.string(),
+    title: z.string().min(1, { message: fieldErrorTooShort }),
+    description: z.string().min(1, { message: fieldErrorTooShort }),
     subtasks: z.array(
       z.object({
-        title: z
-          .string()
-          .min(1, { message: fieldErrorTooShort })
-          .max(20, { message: fieldErrorTooLong }),
+        id: z.optional(z.string()),
+        title: z.string().min(1, { message: fieldErrorTooShort }),
       })
     ),
     columnId: z.string(),

--- a/web-client/src/types/tasks.ts
+++ b/web-client/src/types/tasks.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { fieldErrorTooLong, fieldErrorTooShort } from "@/types/constants"
 
 export const subtaskSchema = z.object({
   id: z.string(),
@@ -36,8 +37,66 @@ export const taskDeleteSchema = z.object({
   message: z.string(),
 })
 
+export const taskFormSchema = z.discriminatedUnion("variant", [
+  z.object({
+    variant: z.literal("create"),
+    title: z
+      .string()
+      .min(1, { message: fieldErrorTooShort })
+      .max(20, { message: fieldErrorTooLong }),
+    description: z.string(),
+    subtasks: z.array(
+      z.object({
+        title: z
+          .string()
+          .min(1, { message: fieldErrorTooShort })
+          .max(20, { message: fieldErrorTooLong }),
+      })
+    ),
+    columnId: z.string(),
+  }),
+  z.object({
+    variant: z.literal("edit"),
+    title: z
+      .string()
+      .min(1, { message: fieldErrorTooShort })
+      .max(20, { message: fieldErrorTooLong }),
+    description: z.string(),
+    subtasks: z.array(
+      z.object({
+        title: z
+          .string()
+          .min(1, { message: fieldErrorTooShort })
+          .max(20, { message: fieldErrorTooLong }),
+      })
+    ),
+    columnId: z.string(),
+  }),
+])
+
 export type Task = z.infer<typeof taskSchema>
 export type Subtask = z.infer<typeof subtaskSchema>
 export type AggregatedSubtask = z.infer<typeof aggregatedSubtaskSchema>
-export type TaskDetailSchema = z.infer<typeof taskDetailSchema>
+export type TaskDetail = z.infer<typeof taskDetailSchema>
 export type TaskDelete = z.infer<typeof taskDeleteSchema>
+export type TaskForm = z.infer<typeof taskFormSchema>
+
+export const isCreateTaskForm = (
+  data: TaskForm
+): data is Extract<TaskForm, { variant: "create" }> => {
+  return data.variant === "create"
+}
+
+export const isEditTaskForm = (
+  data: TaskForm
+): data is Extract<TaskForm, { variant: "edit" }> => {
+  return data.variant === "edit"
+}
+
+export const defaultTaskFormValues: TaskForm = {
+  variant: "create",
+  title: "",
+  description: "",
+  subtasks: [{ title: "" }, { title: "" }],
+  columnId: "",
+}

--- a/web-client/src/utils/helpers/mapData.helpers.ts
+++ b/web-client/src/utils/helpers/mapData.helpers.ts
@@ -1,5 +1,6 @@
-import type { BoardCreate, BoardEdit } from "@/types/api"
-import { BoardForm, isEditBoardForm } from "@/types/boards"
+import { BoardCreate, BoardEdit, TaskCreate, TaskEdit } from "@/types/api"
+import { type BoardForm, isEditBoardForm } from "@/types/boards"
+import { type TaskForm, isEditTaskForm } from "@/types/tasks"
 
 export const mapBoardData = (
   data: BoardForm
@@ -17,6 +18,31 @@ export const mapBoardData = (
       name: data.name,
       columns: data.columns.map((data) => {
         return { name: data.name }
+      }),
+    }
+  }
+}
+
+export const mapTaskData = (
+  data: TaskForm
+): Omit<TaskCreate, "variant"> | Omit<TaskEdit, "variant"> => {
+  if (isEditTaskForm(data)) {
+    return {
+      id: data.id,
+      title: data.title,
+      description: data.description,
+      columnId: data.columnId,
+      subtasks: data.subtasks.map((data) => {
+        return { id: data.id, title: data.title }
+      }),
+    }
+  } else {
+    return {
+      title: data.title,
+      description: data.description,
+      columnId: data.columnId,
+      subtasks: data.subtasks.map((data) => {
+        return { title: data.title }
       }),
     }
   }

--- a/web-client/src/utils/helpers/tasks.helpers.ts
+++ b/web-client/src/utils/helpers/tasks.helpers.ts
@@ -1,9 +1,9 @@
-import type { Subtask, Task, TaskDetailSchema } from "@/types/tasks"
+import type { Subtask, Task, TaskDetail } from "@/types/tasks"
 
 export const mergeTaskWithUpdatedColumnId = (
   task: Task,
   columnId: string
-): TaskDetailSchema => {
+): TaskDetail => {
   const {
     id,
     title,
@@ -25,7 +25,7 @@ export const mergeTaskWithUpdatedColumnId = (
 export const mergeTaskWithUpdatedSubtask = (
   task: Task,
   updatedSubtask: Subtask
-): TaskDetailSchema => {
+): TaskDetail => {
   const {
     id,
     columnId,

--- a/web-client/src/views/Boards/BoardPage/BoardPage.view.tsx
+++ b/web-client/src/views/Boards/BoardPage/BoardPage.view.tsx
@@ -9,9 +9,10 @@ import { EmptyBoard } from "@/views/Placeholders"
 
 export const BoardPage = () => {
   const { boardId } = useParams()
-  const { setSelectedBoard } = useStore(
+  const { setSelectedBoard, handleOpenModal } = useStore(
     useShallow((state) => ({
       setSelectedBoard: state.setSelectedBoard,
+      handleOpenModal: state.handleOpenModal,
     }))
   )
   const { data: boards } = useBoards()
@@ -41,7 +42,11 @@ export const BoardPage = () => {
             )}
           />
         ))}
-        <Button className={"mt-8"} intent={"gridItem"}>
+        <Button
+          className={"mt-8"}
+          intent={"gridItem"}
+          onClick={() => handleOpenModal("EditBoardScreen")}
+        >
           + New Column
         </Button>
       </div>

--- a/web-client/src/views/Modals/HookFormPrimitives/TaskStatusDropdown/TaskStatusDropdown.component.tsx
+++ b/web-client/src/views/Modals/HookFormPrimitives/TaskStatusDropdown/TaskStatusDropdown.component.tsx
@@ -3,10 +3,12 @@ import {
   Controller,
   useFormContext,
   type FieldValues,
+  PathValue,
 } from "react-hook-form"
 
 import { Dropdown, type DropdownItem } from "@/components/forms"
 import { useBoardColumns } from "@/services/queries"
+import { useEffect, useState } from "react"
 
 type Props<T extends FieldValues> = {
   id: string
@@ -24,9 +26,19 @@ export function TaskStatusDropdown<T extends FieldValues>({
   onItemSelect,
   ...props
 }: Props<T>) {
-  const { control } = useFormContext<T>()
-
+  const { control, setValue } = useFormContext<T>()
   const { data: items = [] } = useBoardColumns(boardId)
+  const [selectedOption, setSelectedOption] = useState<
+    DropdownItem | undefined
+  >(items.find((element) => element.id === defaultValue) ?? items[0])
+
+  useEffect(() => {
+    const initialOption = items.find((element) => element.id === defaultValue)
+    if (initialOption) {
+      setSelectedOption(initialOption)
+      setValue(name, initialOption.id as PathValue<T, Path<T>>)
+    }
+  }, [defaultValue, items, name, setValue])
 
   return (
     <Controller
@@ -38,10 +50,12 @@ export function TaskStatusDropdown<T extends FieldValues>({
             {...field}
             {...props}
             items={items.map(({ id, name }) => ({ id, name }))}
-            onItemSelect={onItemSelect}
-            default={
-              items.find((element) => element.id === defaultValue) ?? items[0]
-            }
+            onItemSelect={(item) => {
+              setSelectedOption(item)
+              field.onChange(item.id)
+              onItemSelect(item)
+            }}
+            default={selectedOption}
           />
         )
       }}

--- a/web-client/src/views/Modals/HookFormPrimitives/TaskStatusDropdown/TaskStatusDropdown.component.tsx
+++ b/web-client/src/views/Modals/HookFormPrimitives/TaskStatusDropdown/TaskStatusDropdown.component.tsx
@@ -39,7 +39,9 @@ export function TaskStatusDropdown<T extends FieldValues>({
             {...props}
             items={items.map(({ id, name }) => ({ id, name }))}
             onItemSelect={onItemSelect}
-            default={items.find((element) => element.id === defaultValue)}
+            default={
+              items.find((element) => element.id === defaultValue) ?? items[0]
+            }
           />
         )
       }}

--- a/web-client/src/views/Modals/ModalChildren/AddEditBoardForm/AddEditBoardForm.component.tsx
+++ b/web-client/src/views/Modals/ModalChildren/AddEditBoardForm/AddEditBoardForm.component.tsx
@@ -7,15 +7,18 @@ import { useCreateBoard, useEditBoard } from "@/services/mutations"
 import { CustomTextField } from "@/views/Modals/HookFormPrimitives"
 import type { BoardForm } from "@/types/boards"
 import { useBoardColumns } from "@/services/queries"
-import { SubmitHandler, useFieldArray, useFormContext } from "react-hook-form"
+import { FormProvider, SubmitHandler, useFieldArray } from "react-hook-form"
+import { useBoardFormProvider } from "@/hooks/useBoardFormProvider"
 
 export const AddEditBoardForm = () => {
+  const methods = useBoardFormProvider()
+
   const {
     reset,
     control,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<BoardForm>()
+  } = methods
 
   const { activeModal, selectedBoard, handleCloseModal } = useStore(
     useShallow((state) => ({
@@ -72,58 +75,64 @@ export const AddEditBoardForm = () => {
   }
 
   return (
-    <form className="flex flex-col " onSubmit={handleSubmit(onSubmit)}>
-      <h3 className="text-lg">{isEditMode ? "Edit Board" : "Add New Board"}</h3>
+    <FormProvider {...methods}>
+      <form className="flex flex-col " onSubmit={handleSubmit(onSubmit)}>
+        <h3 className="text-lg">
+          {isEditMode ? "Edit Board" : "Add New Board"}
+        </h3>
 
-      <label
-        className={"text-2xs text-custom-medium-grey my-2"}
-        htmlFor={"name"}
-      >
-        Name
-      </label>
+        <label
+          className={"text-2xs text-custom-medium-grey my-2"}
+          htmlFor={"name"}
+        >
+          Name
+        </label>
 
-      <CustomTextField
-        id="name"
-        name="name"
-        placeholder="e.g. Web Design"
-        errorText={errors?.name?.message}
-      />
+        <CustomTextField
+          id="name"
+          name="name"
+          placeholder="e.g. Web Design"
+          errorText={errors?.name?.message}
+        />
 
-      <label className={"text-2xs text-custom-medium-grey my-4"}>Columns</label>
+        <label className={"text-2xs text-custom-medium-grey my-4"}>
+          Columns
+        </label>
 
-      {fields.map((field, index) => (
-        <Fragment key={field.id}>
-          <RowBlock>
-            <CustomTextField
-              id={`columns.${index}.name`}
-              name={`columns.${index}.name`}
-              placeholder="e.g. Done"
-              errorText={errors?.columns?.[index]?.name?.message}
-            />
-            <Button
-              wrapped={true}
-              iconName={"cross"}
-              onClick={() => {
-                handleRemoveColumn(index)
-              }}
-              intent={"svgOnly"}
-            />
-          </RowBlock>
-        </Fragment>
-      ))}
+        {fields.map((field, index) => (
+          <Fragment key={field.id}>
+            <RowBlock>
+              <CustomTextField
+                id={`columns.${index}.name`}
+                name={`columns.${index}.name`}
+                placeholder="e.g. Done"
+                errorText={errors?.columns?.[index]?.name?.message}
+              />
+              <Button
+                wrapped={true}
+                iconName={"cross"}
+                onClick={() => {
+                  handleRemoveColumn(index)
+                }}
+                intent={"svgOnly"}
+              />
+            </RowBlock>
+          </Fragment>
+        ))}
 
-      <Button
-        type={"submit"}
-        intent={"secondary"}
-        className="w-full my-4"
-        onClick={handleAddColumn}
-      >
-        + Add New Column
-      </Button>
+        <Button
+          type={"submit"}
+          intent={"secondary"}
+          className="w-full my-4"
+          onClick={handleAddColumn}
+        >
+          + Add New Column
+        </Button>
 
-      <Button type={"submit"} intent={"primary"} className="w-full">
-        {isEditMode ? "Save Changes" : "Create New Board"}
-      </Button>
-    </form>
+        <Button type={"submit"} intent={"primary"} className="w-full">
+          {isEditMode ? "Save Changes" : "Create New Board"}
+        </Button>
+      </form>
+    </FormProvider>
   )
 }

--- a/web-client/src/views/Modals/ModalChildren/AddEditTaskForm/AddEditTaskForm.component.tsx
+++ b/web-client/src/views/Modals/ModalChildren/AddEditTaskForm/AddEditTaskForm.component.tsx
@@ -1,0 +1,139 @@
+import { FormProvider, SubmitHandler, useFieldArray } from "react-hook-form"
+import { useTaskFormProvider } from "@/hooks/useTaskFormProvider"
+import { useStore } from "@/store/store"
+import { useShallow } from "zustand/react/shallow"
+import type { TaskForm } from "@/types/tasks"
+import {
+  CustomTextField,
+  TaskStatusDropdown,
+} from "@/views/Modals/HookFormPrimitives"
+import { Fragment } from "react"
+import { RowBlock } from "@/components/grid"
+import { Button, type DropdownItem } from "@/components/forms"
+
+export const AddEditTaskForm = () => {
+  const methods = useTaskFormProvider()
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = methods
+
+  const { activeModal, selectedBoard, handleCloseModal } = useStore(
+    useShallow((state) => ({
+      activeModal: state.activeModal,
+      selectedBoard: state.selectedBoard,
+      handleCloseModal: state.handleCloseModal,
+    }))
+  )
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "subtasks",
+  })
+
+  const isEditMode = activeModal === "EditTaskScreen"
+
+  const handleAddSubtask = () => {
+    append({ title: "" })
+  }
+
+  const handleRemoveSubtask = (index: number) => remove(index)
+
+  const handleDropdownItemSelection = (item: DropdownItem) => {
+    console.log(item)
+  }
+
+  const onSubmit: SubmitHandler<TaskForm> = (data: TaskForm) => {
+    if (data.variant === "create") {
+      console.log("create task")
+    } else {
+      console.log("update task")
+    }
+
+    handleCloseModal()
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <form className="flex flex-col " onSubmit={handleSubmit(onSubmit)}>
+        <h3 className="text-lg">{isEditMode ? "Edit Task" : "Add New Task"}</h3>
+
+        <label
+          className={"text-2xs text-custom-medium-grey my-2"}
+          htmlFor={"title"}
+        >
+          Title
+        </label>
+
+        <CustomTextField
+          id="title"
+          name="title"
+          placeholder="e.g. Take coffee break"
+          errorText={errors?.title?.message}
+        />
+
+        <label
+          className={"text-2xs text-custom-medium-grey my-2"}
+          htmlFor={"description"}
+        >
+          Description
+        </label>
+
+        <CustomTextField
+          id="description"
+          name="description"
+          placeholder="e.g. It's always good to take a break"
+          errorText={errors?.description?.message}
+        />
+
+        <label className={"text-2xs text-custom-medium-grey my-4"}>
+          Subtasks
+        </label>
+
+        {fields.map((field, index) => (
+          <Fragment key={field.id}>
+            <RowBlock>
+              <CustomTextField
+                id={`subtasks.${index}.title`}
+                name={`subtasks.${index}.title`}
+                placeholder="e.g. Make coffee"
+                errorText={errors?.subtasks?.[index]?.title?.message}
+              />
+              <Button
+                wrapped={true}
+                iconName={"cross"}
+                onClick={() => {
+                  handleRemoveSubtask(index)
+                }}
+                intent={"svgOnly"}
+              />
+            </RowBlock>
+          </Fragment>
+        ))}
+        <Button
+          type={"submit"}
+          intent={"secondary"}
+          className="w-full my-4"
+          onClick={handleAddSubtask}
+        >
+          + Add New Subtask
+        </Button>
+
+        <TaskStatusDropdown
+          id="columnId"
+          name="columnId"
+          title={"Status"}
+          boardId={selectedBoard?.id}
+          // defaultValue={}
+          onItemSelect={handleDropdownItemSelection}
+        />
+
+        <Button type={"submit"} intent={"primary"} className="w-full">
+          {isEditMode ? "Save Changes" : "Create Task"}
+        </Button>
+      </form>
+    </FormProvider>
+  )
+}

--- a/web-client/src/views/Modals/ModalChildren/AddEditTaskForm/AddEditTaskForm.component.tsx
+++ b/web-client/src/views/Modals/ModalChildren/AddEditTaskForm/AddEditTaskForm.component.tsx
@@ -7,26 +7,32 @@ import {
   CustomTextField,
   TaskStatusDropdown,
 } from "@/views/Modals/HookFormPrimitives"
-import { Fragment } from "react"
+import { Fragment, useEffect } from "react"
 import { RowBlock } from "@/components/grid"
 import { Button, type DropdownItem } from "@/components/forms"
+import { useCreateTask, useUpdateTask } from "@/services/mutations"
+import { useBoardColumns } from "@/services/queries"
 
 export const AddEditTaskForm = () => {
   const methods = useTaskFormProvider()
 
   const {
+    reset,
     control,
     handleSubmit,
     formState: { errors },
+    setValue,
   } = methods
 
-  const { activeModal, selectedBoard, handleCloseModal } = useStore(
-    useShallow((state) => ({
-      activeModal: state.activeModal,
-      selectedBoard: state.selectedBoard,
-      handleCloseModal: state.handleCloseModal,
-    }))
-  )
+  const { activeModal, selectedBoard, selectedTask, handleCloseModal } =
+    useStore(
+      useShallow((state) => ({
+        activeModal: state.activeModal,
+        selectedTask: state.selectedTask,
+        selectedBoard: state.selectedBoard,
+        handleCloseModal: state.handleCloseModal,
+      }))
+    )
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -34,6 +40,44 @@ export const AddEditTaskForm = () => {
   })
 
   const isEditMode = activeModal === "EditTaskScreen"
+  const createTaskMutation = useCreateTask(selectedBoard?.id)
+  const editTaskMutation = useUpdateTask(selectedBoard?.id)
+  const { data: boardColumns = [] } = useBoardColumns(selectedBoard?.id)
+
+  useEffect(() => {
+    if (isEditMode) {
+      reset({
+        variant: "edit",
+        id: selectedTask?.id,
+        title: selectedTask?.title,
+        description: selectedTask?.description,
+        columnId: selectedTask?.columnId,
+        subtasks: (selectedTask?.subtasks?.data ?? []).map((element) => ({
+          id: element.id,
+          title: element.title,
+        })),
+      })
+
+      if (selectedTask?.columnId) {
+        setValue("columnId", selectedTask.columnId)
+      }
+    }
+  }, [
+    selectedTask?.id,
+    selectedTask?.title,
+    selectedTask?.subtasks?.data,
+    selectedTask?.columnId,
+    isEditMode,
+    reset,
+    setValue,
+  ])
+
+  useEffect(() => {
+    if (!isEditMode && boardColumns.length > 0) {
+      const defaultColumnId = boardColumns[0]?.id
+      setValue("columnId", defaultColumnId)
+    }
+  }, [isEditMode, boardColumns, setValue])
 
   const handleAddSubtask = () => {
     append({ title: "" })
@@ -42,14 +86,14 @@ export const AddEditTaskForm = () => {
   const handleRemoveSubtask = (index: number) => remove(index)
 
   const handleDropdownItemSelection = (item: DropdownItem) => {
-    console.log(item)
+    setValue("columnId", item.id)
   }
 
   const onSubmit: SubmitHandler<TaskForm> = (data: TaskForm) => {
     if (data.variant === "create") {
-      console.log("create task")
+      createTaskMutation.mutate(data)
     } else {
-      console.log("update task")
+      editTaskMutation.mutate(data)
     }
 
     handleCloseModal()
@@ -115,7 +159,7 @@ export const AddEditTaskForm = () => {
         <Button
           type={"submit"}
           intent={"secondary"}
-          className="w-full my-4"
+          className="w-full"
           onClick={handleAddSubtask}
         >
           + Add New Subtask
@@ -126,11 +170,11 @@ export const AddEditTaskForm = () => {
           name="columnId"
           title={"Status"}
           boardId={selectedBoard?.id}
-          // defaultValue={}
+          defaultValue={selectedTask?.columnId}
           onItemSelect={handleDropdownItemSelection}
         />
 
-        <Button type={"submit"} intent={"primary"} className="w-full">
+        <Button type={"submit"} intent={"primary"} className="w-full mt-6">
           {isEditMode ? "Save Changes" : "Create Task"}
         </Button>
       </form>

--- a/web-client/src/views/Modals/ModalChildren/ViewTaskDetail/ViewTaskDetail.component.tsx
+++ b/web-client/src/views/Modals/ModalChildren/ViewTaskDetail/ViewTaskDetail.component.tsx
@@ -41,7 +41,7 @@ export const ViewTaskDetail = () => {
     event.preventDefault()
   }
 
-  const handleItemSelection = (item: DropdownItem) => {
+  const handleDropdownItemSelection = (item: DropdownItem) => {
     if (!activeTask) {
       return
     }
@@ -85,7 +85,7 @@ export const ViewTaskDetail = () => {
               title={"Current Status"}
               boardId={selectedBoard?.id}
               defaultValue={activeTask.columnId}
-              onItemSelect={handleItemSelection}
+              onItemSelect={handleDropdownItemSelection}
             />
           )}
         </form>

--- a/web-client/src/views/Modals/ModalChildren/index.tsx
+++ b/web-client/src/views/Modals/ModalChildren/index.tsx
@@ -1,4 +1,5 @@
 export { AddEditBoardForm } from "./AddEditBoardForm/AddEditBoardForm.component"
+export { AddEditTaskForm } from "./AddEditTaskForm/AddEditTaskForm.component"
 export { DeleteBoard } from "./DeleteBoard/DeleteBoard.component"
 export { ViewTaskDetail } from "./ViewTaskDetail/ViewTaskDetail.component"
 export { DeleteTask } from "./DeleteTask/DeleteTask.component"

--- a/web-client/src/views/Modals/ModalContainer/ModalContainer.component.tsx
+++ b/web-client/src/views/Modals/ModalContainer/ModalContainer.component.tsx
@@ -1,17 +1,18 @@
 import React, { useEffect, useRef } from "react"
 import { createPortal } from "react-dom"
-import { FormProvider } from "react-hook-form"
 import { useStore } from "@/store/store"
 import { useShallow } from "zustand/react/shallow"
 import * as modalChildren from "@/views/Modals/ModalChildren"
 import type { ModalScreenKey } from "@/types/modals"
-import { useBoardFormProvider } from "@/hooks/useBoardFormProvider"
 
 const ModalChild = (modalScreenKey: ModalScreenKey) => {
   switch (modalScreenKey) {
     case "AddBoardScreen":
     case "EditBoardScreen":
       return modalChildren["AddEditBoardForm"]
+    case "AddTaskScreen":
+    case "EditTaskScreen":
+      return modalChildren["AddEditTaskForm"]
     case "DeleteBoardScreen":
       return modalChildren["DeleteBoard"]
     case "ViewTaskDetailScreen":
@@ -32,8 +33,6 @@ export const ModalContainer = () => {
       clearSelectedTask: state.clearSelectedTask,
     }))
   )
-
-  const methods = useBoardFormProvider(activeModal)
 
   const modalRootId = document.getElementById("modal")
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -121,9 +120,7 @@ export const ModalContainer = () => {
             ref={contentRef}
             className="w-[30rem] px-8 pt-8 pb-10 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-custom-white rounded-md"
           >
-            <FormProvider {...methods}>
-              {React.createElement(modalChild)}
-            </FormProvider>
+            {React.createElement(modalChild)}
           </div>
         </div>
       </>,

--- a/web-client/src/views/Placeholders/EmptyBoard/EmptyBoard.view.tsx
+++ b/web-client/src/views/Placeholders/EmptyBoard/EmptyBoard.view.tsx
@@ -1,12 +1,23 @@
 import { Button } from "@/components/forms"
+import { useStore } from "@/store/store"
+import { useShallow } from "zustand/react/shallow"
 
 export const EmptyBoard = () => {
+  const { handleOpenModal } = useStore(
+    useShallow((state) => ({
+      handleOpenModal: state.handleOpenModal,
+    }))
+  )
+
   return (
     <div className="flex bg-custom-light-grey flex-grow border-t-2 flex-col w-28 justify-center items-center gap-y-6">
       <p className="text-lg text-custom-medium-grey">
         This board is empty. Create a new column to get started.
       </p>
-      <Button className="w-40" onClick={() => {}}>
+      <Button
+        className="w-40"
+        onClick={() => handleOpenModal("EditBoardScreen")}
+      >
         + Add New Column
       </Button>
     </div>


### PR DESCRIPTION
## Description

In this PR, we are adding a missing functionality for creating and updating tasks. We are using a similar approach like in the case of the Board creation and edit, in this case, however, we are utilizing a slightly more complex schema.

There are some minor differences between the original design and this implementation, all will be addressed in a separated PR.

### Screenshots

### Creating a new task

<img width="1792" alt="Screenshot 2024-11-13 at 1 17 11 PM" src="https://github.com/user-attachments/assets/46ee98f9-9e4b-4757-8b89-e5efd56037ca">

### Updating an existing task

<img width="1792" alt="Screenshot 2024-11-13 at 1 18 05 PM" src="https://github.com/user-attachments/assets/115700d8-eccf-4bbc-bae0-0ae85c5a01b8">

